### PR TITLE
Library ready for unit different than Smarteverything

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ be easily adapt and use on every Arduino and Arduino Certified boards.
 
 ## Releases  
 ---  
-#### v1.0.0 First Release  
+#### v1.2.0 Second Release 18-Jul-2016
+* Enachement:<br>  
+    Unlocked the library from the SME specific UART. The User can change the serial at the begin() method.<br>.  
 #### v1.0.1 Second Release 19-Dec-2015  
 * Fixed Issue:<br>  
     Added examples and API to trigger GPS module power status. This can be useful to reduce power consumption<br>.  
- 
+#### v1.0.0 First Release  
+
 ## Documentation
 --------------
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ be easily adapt and use on every Arduino and Arduino Certified boards.
 ## Releases  
 ---  
 #### v1.2.0 Second Release 18-Jul-2016
-* Enachement:<br>  
-    Unlocked the library from the SME specific UART. The User can change the serial at the begin() method.<br>.  
+* Enachement:  
+    Unlocked the library from the SME specific UART. The User can change the serial at the begin() method.<br>
+
 #### v1.0.1 Second Release 19-Dec-2015  
-* Fixed Issue:<br>  
-    Added examples and API to trigger GPS module power status. This can be useful to reduce power consumption<br>.  
+* Fixed Issue:  
+    Added examples and API to trigger GPS module power status. This can be useful to reduce power consumption<br>.
+
 #### v1.0.0 First Release  
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ be easily adapt and use on every Arduino and Arduino Certified boards.
 
 ## Releases  
 ---  
-#### v1.2.0 Second Release 18-Jul-2016
+#### v1.1.0 Third Release 18-Jul-2016
 * Enachement:  
     Unlocked the library from the SME specific UART. The User can change the serial at the begin() method.<br>
 

--- a/examples/GPS/LocalizationInfo/LocalizationInfo.ino
+++ b/examples/GPS/LocalizationInfo/LocalizationInfo.ino
@@ -43,8 +43,9 @@ void loop() {
     delay(5);
 
     if (smeGps.ready()) {
-
+#ifdef ARDUINO_SAMD_SMARTEVERYTHING
         ledGreenLight(HIGH);
+#endif
 
         altitude   = smeGps.getAltitude();
         latitude   = smeGps.getLatitude();
@@ -74,5 +75,7 @@ void loop() {
     }
 
     loop_cnt++;
+#ifdef ARDUINO_SAMD_SMARTEVERYTHING
     ledGreenLight(led_status);
+#endif
 }

--- a/examples/GPS/PowerModes/PowerModes.ino
+++ b/examples/GPS/PowerModes/PowerModes.ino
@@ -1,5 +1,5 @@
 /*
-    SmeGPS Library - Localization Information
+    SmeGPS Library - Power modes
 
     This example shows how to trigger the GPS module power status:
     Standby, Warm, Cold and Hot restarts.
@@ -36,7 +36,7 @@ typedef enum   {
 
 const unsigned char LOOP_DELAY     = 5;   // 5 ms
 const unsigned int  MS_IN_S        = 1000;
- 
+
 const unsigned int  PRINT_PERIOD   = 2*(MS_IN_S)/LOOP_DELAY; // 2 sec  
 
 gpsStatus_t gpsStatus = GPS_HOT;
@@ -45,14 +45,14 @@ gpsStatus_t gpsStatus = GPS_HOT;
 #define checkToPrint(loop)  ((loop%PRINT_PERIOD) == 0)
 
 
-    
+
 // the setup function runs once when you press reset or power the board
 void setup() {
     SerialUSB.begin(115200);
     smeGps.begin();
 
     while (!SerialUSB) {
-       ;
+        ;
     }
 
     SerialUSB.println("Press one of the following keys to change Power Status:");
@@ -68,7 +68,7 @@ void printGpsData(void)
     double latitude                = smeGps.getLatitude();
     double longitude               = smeGps.getLongitude();
     unsigned char lockedSatellites = smeGps.getLockedSatellites();
-    
+
     SerialUSB.println(" ");
     SerialUSB.print("Latitude    =  ");
     SerialUSB.println(latitude, 6);
@@ -93,37 +93,45 @@ void loop()
 
         switch (inChar) {
         case 's':  gpsStatus = GPS_STANDBY;
-            SerialUSB.println("Set GPS to Standby...");
-            smeGps.setStandby();
-            ledBlueLight(HIGH);
-            delay(500);
-            ledBlueLight(LOW);
+        SerialUSB.println("Set GPS to Standby...");
+        smeGps.setStandby();
+#ifdef ARDUINO_SAMD_SMARTEVERYTHING
+        ledBlueLight(HIGH);
+        delay(500);
+        ledBlueLight(LOW);
+#endif
         break;
         case 'h':  gpsStatus = GPS_HOT;
-		        SerialUSB.println("GPS Hot Restart...");
-            smeGps.setHotRestart();
-            ledBlueLight(HIGH);
-            ledRedLight(HIGH);
-            delay(500);
-            ledBlueLight(LOW);
-            ledRedLight(LOW);
+        SerialUSB.println("GPS Hot Restart...");
+        smeGps.setHotRestart();
+#ifdef ARDUINO_SAMD_SMARTEVERYTHING
+        ledBlueLight(HIGH);
+        ledRedLight(HIGH);
+        delay(500);
+        ledBlueLight(LOW);
+        ledRedLight(LOW);
+#endif
         break;
         case 'w':  gpsStatus = GPS_WARM;
-            SerialUSB.println("GPS Warm Restart...");
-            smeGps.setWarmRestart();
-            ledGreenLight(HIGH);
-            delay(500);
-            ledGreenLight(LOW);
+        SerialUSB.println("GPS Warm Restart...");
+        smeGps.setWarmRestart();
+#ifdef ARDUINO_SAMD_SMARTEVERYTHING
+        ledGreenLight(HIGH);
+        delay(500);
+        ledGreenLight(LOW);
+#endif
         break;
         case 'c':  gpsStatus = GPS_COLD;
-            SerialUSB.println("GPS Cold Restart...");
-            smeGps.setColdRestart();
-            ledRedLight(HIGH);
-            delay(500);
-            ledRedLight(LOW);
+        SerialUSB.println("GPS Cold Restart...");
+        smeGps.setColdRestart();  
+#ifdef ARDUINO_SAMD_SMARTEVERYTHING
+        ledRedLight(HIGH);
+        delay(500);
+        ledRedLight(LOW);
+#endif
         break;
         default:
-        break;
+            break;
         }
     } 
 

--- a/src/gps/sl868a.cpp
+++ b/src/gps/sl868a.cpp
@@ -111,7 +111,7 @@ Sl868a::setHotRestart(void)
  int
  Sl868a::print(const char *msg)
  {
-    GPS.print((const char*)msg);
+    gpsComm->print((const char*)msg);
     return SME_OK;
  }
 
@@ -119,9 +119,9 @@ Sl868a::setHotRestart(void)
  void
  Sl868a::readData(void)
  {
-     while (GPS.available()) {
+     while (gpsComm->available()) {
          // get the new byte:
-         char inChar = (char)GPS.read();
+         char inChar = (char)gpsComm->read();
          handleGpsRxData(inChar);
      }
  }
@@ -141,8 +141,9 @@ Sl868a::setHotRestart(void)
      _ready = false;
  }
 
- void Sl868a::begin (void) {
-     GPS.begin(9600);
+ void Sl868a::begin (Uart *serial) {
+     this->gpsComm = serial;
+     gpsComm->begin(9600);
  }
 
 

--- a/src/sl868a.h
+++ b/src/sl868a.h
@@ -36,6 +36,7 @@ public:
     virtual ~Sl868a(){};
 
 private:
+    Uart *gpsComm;
     bool crcCheck(uint8_t data[], uint8_t len);
     uint8_t handleGpsRxData(uint8_t inChar);
     void parseGpsRxMsg (void);
@@ -70,7 +71,13 @@ private:
 // library API
 public:
 
-    void begin (void);
+    #ifdef ARDUINO_SAMD_SMARTEVERYTHING
+    void begin(Uart *serial=&GPS);
+    #elif defined (ASME3_REVISION)
+    void begin(Uart *serial=&GPS);
+    #else
+    void begin(Uart *serial=&Serial1);
+    #endif
     void setStandby();
     void setWarmRestart();
     void setHotRestart();


### PR DESCRIPTION
@searobin Please have a look to the new library.
It could be used by any other Arduino units.
The begin() method check which unit is selected and use the corect UART
for the SmartEverything the internal one
for any other unit the Serial1, that is present in all the Arduino unit.

The user can change the serial at the begin() method
