### PR TITLE
Fixed compatibility change with ARDUINO_SAMD_SMARTEVERYTHING (no _FOX)

### DIFF
--- a/src/sl868a.h
+++ b/src/sl868a.h
@@ -84,9 +84,11 @@ private:
 public:
 
 #ifdef ARDUINO_SAMD_SMARTEVERYTHING_FOX
-    void begin(Uart *serial=&GPS);
+    void begin(Uart *serial = &GPS);
+#elif defined (ARDUINO_SAMD_SMARTEVERYTHING)
+	void begin(Uart *serial = &GPS);
 #elif defined (ASME3_REVISION)
-    void begin(Uart *serial=&GPS);
+	void begin(Uart *serial = &GPS);
 #else
     void begin(Uart *serial=&Serial1);
 #endif


### PR DESCRIPTION
Didn't work with some SmartEverything boards because they do not have ARDUINO_SAMD_SMARTEVERYTHING_FOX declared