### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,7 +5,7 @@
 #######################################
 # Library (KEYWORD3)
 #######################################
-smeGps	     KEYWORD3
+smeGps	KEYWORD3
 
 #######################################
 # Datatypes (KEYWORD1)
@@ -14,26 +14,26 @@ smeGps	     KEYWORD3
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin	             KEYWORD2
-setStandby           KEYWORD2
-setWarmRestart       KEYWORD2
-setHotRestart        KEYWORD2
-setColdRestart       KEYWORD2
-ready                KEYWORD2
-getAltitude	         KEYWORD2
-getLatitude	         KEYWORD2
-getLongitude	     KEYWORD2
-getLockedSatellites  KEYWORD2
-getUtcHour           KEYWORD2
-getUtcMinute         KEYWORD2
-getUtcSecond         KEYWORD2
-getUtcSecondDecimals KEYWORD2
-getUtcYear           KEYWORD2
-getUtcMonth          KEYWORD2
-getUtcDayOfMonth     KEYWORD2
-getSpeedKnots        KEYWORD2
-getCourse            KEYWORD2
-getData              KEYWORD2
+begin	KEYWORD2
+setStandby	KEYWORD2
+setWarmRestart	KEYWORD2
+setHotRestart	KEYWORD2
+setColdRestart	KEYWORD2
+ready	KEYWORD2
+getAltitude	KEYWORD2
+getLatitude	KEYWORD2
+getLongitude	KEYWORD2
+getLockedSatellites	KEYWORD2
+getUtcHour	KEYWORD2
+getUtcMinute	KEYWORD2
+getUtcSecond	KEYWORD2
+getUtcSecondDecimals	KEYWORD2
+getUtcYear	KEYWORD2
+getUtcMonth	KEYWORD2
+getUtcDayOfMonth	KEYWORD2
+getSpeedKnots	KEYWORD2
+getCourse	KEYWORD2
+getData	KEYWORD2
     
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords